### PR TITLE
nrf_802154: Change init priority for configure module

### DIFF
--- a/subsys/ieee802154/nrf_802154_configurator.c
+++ b/subsys/ieee802154/nrf_802154_configurator.c
@@ -50,8 +50,10 @@ static int nrf_802154_configure(const struct device *dev)
 }
 
 #if IS_ENABLED(CONFIG_NRF_802154_SER_RADIO)
-#define INIT_PRIO CONFIG_NRF_802154_SER_RADIO_INIT_PRIO
+#define INIT_LEVEL APPLICATION
+#define INIT_PRIO CONFIG_APPLICATION_INIT_PRIORITY
 #elif IS_ENABLED(CONFIG_IEEE802154_NRF5)
+#define INIT_LEVEL POST_KERNEL
 #define INIT_PRIO CONFIG_IEEE802154_NRF5_INIT_PRIO
 #else
 /* There is no defined priority of nRF 802.15.4 Radio Driver's initialization.
@@ -64,4 +66,4 @@ BUILD_ASSERT(INIT_PRIO < CONFIG_NRF_802154_RADIO_CONFIG_PRIO,
 	     "nRF 802.15.4 driver configuration would not be performed after its initialization");
 #endif
 
-SYS_INIT(nrf_802154_configure, POST_KERNEL, CONFIG_NRF_802154_RADIO_CONFIG_PRIO);
+SYS_INIT(nrf_802154_configure, INIT_LEVEL, CONFIG_NRF_802154_RADIO_CONFIG_PRIO);


### PR DESCRIPTION
The init priority for nrf_802154_configurator was changed
to run after the nrf_802154 driver is initialized.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>