### PR TITLE
fix: tests: Remove integration_platforms with empty lists

### DIFF
--- a/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_async_api/testcase.yaml
@@ -4,5 +4,5 @@ tests:
     tags: osif_serial
     harness_config:
       fixture: shorted_uart_1
-    integration_platforms:
-      - null # No integration platforms because test requires shorted UART 1 pins
+    # integration_platforms:
+    #  - null # No integration platforms because test requires shorted UART 1 pins

--- a/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
+++ b/tests/subsys/zigbee/osif/serial/serial_basic_api/testcase.yaml
@@ -4,5 +4,5 @@ tests:
     tags: osif_serial
     harness_config:
       fixture: shorted_uart_1
-    integration_platforms:
-      - null # No integration platforms because test requires shorted UART 1 pins
+    # integration_platforms:
+    #  - null # No integration platforms because test requires shorted UART 1 pins


### PR DESCRIPTION
The fix is needed because Twister doesn't recognize "null" as
a valid platform name

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>