### PR TITLE
nrf_802154: fix: Undefined initialization levels used fixed

### DIFF
--- a/subsys/ieee802154/nrf_802154_configurator.c
+++ b/subsys/ieee802154/nrf_802154_configurator.c
@@ -56,6 +56,7 @@ static int nrf_802154_configure(const struct device *dev)
 #define INIT_LEVEL POST_KERNEL
 #define INIT_PRIO CONFIG_IEEE802154_NRF5_INIT_PRIO
 #else
+#define INIT_LEVEL POST_KERNEL
 /* There is no defined priority of nRF 802.15.4 Radio Driver's initialization.
  * No priority validation can be performed.
  */


### PR DESCRIPTION
TOP_LEVEL wasn't defined in nrf_802154_configurator.c if the application
used the 802.15.4 nrf API directly and not through zephyr API. This
caused that the SYS_INIT macro was called without any arguments, thus
leading to an "Undefined initialization levels used" error when linking.