### PR TITLE
subsys: nrf_rpc: RPC opening second IPC endpoint fix

### DIFF
--- a/subsys/nrf_rpc/nrf_rpc_rpmsg.c
+++ b/subsys/nrf_rpc/nrf_rpc_rpmsg.c
@@ -101,7 +101,7 @@ int nrf_rpc_tr_init(nrf_rpc_tr_receive_handler_t callback)
 	nrf_rpc_ipc_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
 
 	err = ipc_service_open_instance(nrf_rpc_ipc_instance);
-	if (err < 0) {
+	if (err < 0 && err != -EALREADY) {
 		NRF_RPC_ERR("IPC service instance initialization failed: %d\n", err);
 		return translate_error(err);
 	}


### PR DESCRIPTION
If before calling nrf_rpc_tr_init ipc_service_open_instance was called
by another function then ipc_service_open_instance returned -EALREADY
and RPC initialization failed. This should not happen as such situation
is possible when using two IPC endpoint and it is not an error.