### PR TITLE
cmake: escape values of variables in preload

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -78,7 +78,7 @@ else()
     file(
       APPEND
       ${base_image_preload_file}
-      "set(${app_var_name} ${${app_var_name}} CACHE INTERNAL \"NCS child image controlled\")\n"
+      "set(${app_var_name} \"${${app_var_name}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
       )
   endforeach()
 
@@ -377,7 +377,7 @@ function(add_child_image_from_source)
       file(
         APPEND
         ${preload_file}
-        "set(${CMAKE_MATCH_1} ${${var_name}} CACHE INTERNAL \"NCS child image controlled\")\n"
+        "set(${CMAKE_MATCH_1} \"${${var_name}}\" CACHE INTERNAL \"NCS child image controlled\")\n"
         )
     endforeach()
   endif()


### PR DESCRIPTION
Without this fix variables with space in them will be incorrect
when evaluated.

Ref: NCSDK-14272
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>