### PR TITLE
samples: nrf9160: modem_shell: thingy: more FLASH needed

### DIFF
--- a/samples/nrf9160/modem_shell/boards/thingy91_nrf9160_ns.conf
+++ b/samples/nrf9160/modem_shell/boards/thingy91_nrf9160_ns.conf
@@ -12,6 +12,7 @@
 CONFIG_MOSH_CURL=n
 CONFIG_MOSH_REST=n
 CONFIG_MOSH_SMS=n
+CONFIG_MOSH_IPERF3=n
 
 # Disabling also APP FOTA to fit MOSH into flash. Notice that this doesn't free
 # entire partitions of memory as Zephyr uses MCU partitions still in default thingy91 configs.


### PR DESCRIPTION
Disabled iperf3 from Thingy config in order to fit into a FLASH.

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>