### PR TITLE
bootloader: don't use NRF_RTC_TIMER

### DIFF
--- a/samples/bootloader/prj.conf
+++ b/samples/bootloader/prj.conf
@@ -26,3 +26,6 @@ CONFIG_TIMEOUT_64BIT=n
 
 # Disable asserts because of false positive when writing to OTP.
 CONFIG_ASSERT=n
+
+# Avoid triggering IRQs from the RTC
+CONFIG_NRF_RTC_TIMER=n


### PR DESCRIPTION
Avoid IRQs while booting.

Ref: NCSDK-14392
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>